### PR TITLE
Add delete row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,12 +714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1284,6 +1278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,9 +1621,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -1696,34 +1696,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
  "proc-macro2",
  "quote",
- "syn 1.0.95",
+ "syn 2.0.50",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1731,22 +1732,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.95",
+ "syn 2.0.50",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wayland-backend"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ urlencoding = "2.1.0"
 [features]
 default = ["arboard"]
 clip = ["arboard"]
+cli-clipboard = []
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 totp-rs = "3.1.0"
 chrono = "0.4"
 data-encoding = "2.1.1"
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.88"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.61.0-bullseye as builder
+FROM rust:1.82.0-bullseye as builder
 WORKDIR /usr/src/totp
 RUN sed -i "s#http://deb.debian.org/#https://debian.mirror.ac.za/#g" /etc/apt/sources.list
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82.0-bullseye as builder
+FROM rust:1.86.0-bullseye as builder
 WORKDIR /usr/src/totp
 RUN sed -i "s#http://deb.debian.org/#https://debian.mirror.ac.za/#g" /etc/apt/sources.list
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ Options:
 | `Up`        | Select previous account         |
 | `Enter`     | Copy OTP or Detail to clipboard |
 | `Ctrl-c`    | Exit                            |
+| `d`         | Delete selected account         |

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -48,7 +48,7 @@ pub enum Connection<'a> {
     Transaction(Transaction<'a>),
 }
 
-impl<'a> TryFrom<&Db> for Connection<'a> {
+impl TryFrom<&Db> for Connection<'_> {
     type Error = TotpError;
 
     fn try_from(db: &Db) -> Result<Self, Self::Error> {

--- a/src/db/models/secure_record.rs
+++ b/src/db/models/secure_record.rs
@@ -31,7 +31,7 @@ impl SecureRecord {
     }
 }
 
-impl<'stmt> From<&Row<'stmt>> for SecureRecord {
+impl From<&Row<'_>> for SecureRecord {
     fn from(row: &Row) -> Self {
         Self {
             id: row.get(0).unwrap(),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,7 @@ pub enum TotpError {
     HttpServer(String),
     R2d2(String),
     Migration(String),
+    Storage(String),
     SecretParseError(String),
     ClipboardError(String),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,24 +7,41 @@ use totp_rs::TotpUrlError;
 
 #[derive(Debug)]
 pub enum TotpError {
+    #[allow(dead_code)]
     AccountNotFound(String),
+    #[allow(dead_code)]
     Base32Decode(String),
+    #[allow(dead_code)]
     Clap(String),
+    #[allow(dead_code)]
     TotpUrl(String),
+    #[allow(dead_code)]
     Format(String),
+    #[allow(dead_code)]
     Encryption(String),
+    #[allow(dead_code)]
     Decryption(String),
     MissingLockKey,
+    #[allow(dead_code)]
     Utf8(String),
     InvalidOtpForRange,
+    #[allow(dead_code)]
     Ui(String),
+    #[allow(dead_code)]
     UiEvent(String),
+    #[allow(dead_code)]
     Json(String),
+    #[allow(dead_code)]
     HttpServer(String),
+    #[allow(dead_code)]
     R2d2(String),
+    #[allow(dead_code)]
     Migration(String),
+    #[allow(dead_code)]
     Storage(String),
+    #[allow(dead_code)]
     SecretParseError(String),
+    #[allow(dead_code)]
     ClipboardError(String),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use crate::db::models::record::Record;
 use crate::db::Db;
 use crate::errors::TotpError;
 use crate::ui::app::App;
-use crate::ui::clip::set_clipboard;
 use crate::ui::event_handler::{Event, EventHandler};
 use crate::ui::tui::Tui;
 use chrono::{DateTime, FixedOffset};

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -17,7 +17,7 @@ pub struct App {
     pub detail_state: ListState,
 }
 impl App {
-    pub fn new<T: StorageTrait>(storage: T) -> Result<Self, TotpError> {
+    pub fn new<T: StorageTrait + 'static>(storage: T) -> Result<Self, TotpError> {
         Ok(Self {
             state: State::new(storage)?,
             table_state: TableState::default(),

--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -11,8 +11,10 @@ pub enum Event {
     /// Key press.
     Key(KeyEvent),
     /// Mouse click/scroll.
+    #[allow(dead_code)]
     Mouse(MouseEvent),
     /// Terminal resize.
+    #[allow(dead_code)]
     Resize(u16, u16),
     /// Terminal tick.
     Tick,

--- a/src/ui/handler.rs
+++ b/src/ui/handler.rs
@@ -2,6 +2,10 @@ use crate::ui::state::{ActivePane, InputMode};
 use crate::{App, TotpError, Tui};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tui::backend::Backend;
+use tui::style::Color;
+use tui::style::Style;
+
+use super::widgets::popup::Popup;
 
 pub fn handle_key_events<B: Backend>(
     key_event: KeyEvent,
@@ -25,6 +29,7 @@ pub fn handle_key_events<B: Backend>(
         InputMode::Normal => handle_normal_mode(key_event, app),
         InputMode::FilterList => handle_input_mode(key_event, app),
         InputMode::EditDetail => handle_edit_details(key_event, app),
+        InputMode::DeleteConfirmation => handle_delete_confirmation(key_event, app)?,
     }
 
     Ok(())
@@ -38,6 +43,20 @@ pub fn handle_normal_mode(key_event: KeyEvent, app: &mut App) {
         (KeyCode::Char('e'), _) => {
             if app.state.active_pane == ActivePane::DetailView {
                 app.state.input_mode = InputMode::EditDetail;
+            }
+        }
+        (KeyCode::Char('d'), _) => {
+            if app.state.active_pane == ActivePane::OtpTable && app.table_state.selected().is_some() {
+                app.state.input_mode = InputMode::DeleteConfirmation;
+                app.state.show_popup = Some(Popup {
+                    title: "Confirm Delete".to_string(),
+                    message: Some("Press 'y' to confirm or 'n' to cancel".to_string()),
+                    style: Some(Style::default().fg(Color::Red)),
+                    show_background: Some(true),
+                    show_until: None,
+                    size: None,
+                    position: None,
+                });
             }
         }
         (KeyCode::Char('q'), _) => app.state.running = false,
@@ -73,4 +92,30 @@ pub fn handle_input_mode(key_event: KeyEvent, app: &mut App) {
         }
         _ => {}
     }
+}
+
+pub fn handle_delete_confirmation(key_event: KeyEvent, app: &mut App) -> Result<(), TotpError> {
+    let code = key_event.code;
+    match code {
+        KeyCode::Char('y') => {
+            if let Some(selected) = app.table_state.selected() {
+                if let Some((_, _, _, record_id)) = app.state.display_otps.get(selected) {
+                    if let Some(storage) = app.state.storage.as_mut() {
+                        storage.remove_account_by_id(*record_id)?;
+                        app.state.build_records()?;
+                      
+                        // app.state.records = records;
+                    }
+                }
+            }
+            app.state.input_mode = InputMode::Normal;
+            app.state.show_popup = None;
+        }
+        KeyCode::Char('n') | KeyCode::Esc => {
+            app.state.input_mode = InputMode::Normal;
+            app.state.show_popup = None;
+        }
+        _ => {}
+    }
+    Ok(())
 }

--- a/src/ui/handler.rs
+++ b/src/ui/handler.rs
@@ -46,7 +46,8 @@ pub fn handle_normal_mode(key_event: KeyEvent, app: &mut App) {
             }
         }
         (KeyCode::Char('d'), _) => {
-            if app.state.active_pane == ActivePane::OtpTable && app.table_state.selected().is_some() {
+            if app.state.active_pane == ActivePane::OtpTable && app.table_state.selected().is_some()
+            {
                 app.state.input_mode = InputMode::DeleteConfirmation;
                 app.state.show_popup = Some(Popup {
                     title: "Confirm Delete".to_string(),
@@ -103,7 +104,7 @@ pub fn handle_delete_confirmation(key_event: KeyEvent, app: &mut App) -> Result<
                     if let Some(storage) = app.state.storage.as_mut() {
                         storage.remove_account_by_id(*record_id)?;
                         app.state.build_records()?;
-                      
+
                         // app.state.records = records;
                     }
                 }

--- a/src/ui/handler.rs
+++ b/src/ui/handler.rs
@@ -112,11 +112,10 @@ pub fn handle_delete_confirmation(key_event: KeyEvent, app: &mut App) -> Result<
             app.state.input_mode = InputMode::Normal;
             app.state.show_popup = None;
         }
-        KeyCode::Char('n') | KeyCode::Esc => {
+        _ => {
             app.state.input_mode = InputMode::Normal;
             app.state.show_popup = None;
         }
-        _ => {}
     }
     Ok(())
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,7 +11,7 @@ mod state;
 pub mod tui;
 pub mod widgets;
 
-pub fn init<T: StorageTrait>(storage: T) -> Result<(), TotpError> {
+pub fn init<T: StorageTrait + 'static>(storage: T) -> Result<(), TotpError> {
     let mut app: App = App::new(storage)?;
     let backend = CrosstermBackend::new(io::stdout());
     let terminal = Terminal::new(backend)?;

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -78,7 +78,10 @@ impl State {
     pub fn build_records(&mut self) -> Result<(), TotpError> {
         let mut items = vec![];
         let mut records = vec![];
-        for record in self.storage.as_ref().ok_or(TotpError::Storage("Storage not found".to_string()))?
+        for record in self
+            .storage
+            .as_ref()
+            .ok_or(TotpError::Storage("Storage not found".to_string()))?
             .accounts()?
             .iter()
         {


### PR DESCRIPTION
This pull request introduces a new feature to support deleting accounts in the TOTP application, along with some other updates and improvements. The most significant changes include adding a delete confirmation workflow, enhancing the `State` and `App` structures to handle storage dynamically, and updating dependencies.

### New Feature: Delete Account Workflow

* Added a new `DeleteConfirmation` input mode to handle the delete confirmation process (`src/ui/state.rs`).
* Implemented the `handle_delete_confirmation` function to process user confirmation for deleting accounts (`src/ui/handler.rs`).
* Updated the `handle_normal_mode` function to trigger the delete confirmation popup when the `d` key is pressed (`src/ui/handler.rs`).
* Introduced a popup UI element to display the delete confirmation message (`src/ui/handler.rs`).

### Structural Enhancements

* Modified the `State` struct to include an optional `storage` field for dynamic storage handling (`src/ui/state.rs`).
* Updated the `State::new` method to initialize storage and build records dynamically (`src/ui/state.rs`).
* Refactored the `build_records` method to populate the state with OTP records from storage (`src/ui/state.rs`).

### Dependency Updates

* Upgraded the Rust version in the `Dockerfile` from `1.61.0` to `1.82.0` for compatibility and performance improvements (`Dockerfile`).

### Documentation Updates

* Updated the `README.md` to include the new `d` keybinding for deleting accounts (`README.md`).

### Error Handling Improvements

* Added a new `Storage` variant to the `TotpError` enum for better error reporting related to storage issues (`src/errors.rs`).